### PR TITLE
Rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Read more at [OpenSAFELY.org](https://opensafely.org).
 The framework is under fast, active development to support rapid
 analytics relating to COVID19; we're currently seeking funding to make
 it easier for outside collaborators to work with our system.  You can
-read our current roadmap [here](https://github.com/ebmdatalab/opensafely-research-template/blob/main/ROADMAP.md).
+read our current roadmap [here](https://github.com/ebmdatalab/opensafely-research-template/blob/master/ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ NHS patients_
 * If you are interested in how we defined our code lists, look in the [codelists folder](./codelists/). A new tool
 called OpenSafely Codelists was developed to allow codelists to be versioned and hosted online at [codelists.opensafely.org](http://codelists.opensafely.org)
 The tool allows agreed codelists to be pulled into a repository by running a Python command. More information available in
-the [README](https://github.com/ebmdatalab/opensafely-risk-factors-research/blob/master/codelists/README.md) of the codelist folder
+the [README](codelists/README.md) of the codelist folder
 * Developers and epidemiologists interested in the code should review
 [DEVELOPERS.md](./DEVELOPERS.md).
 
@@ -28,4 +28,4 @@ Read more at [OpenSAFELY.org](https://opensafely.org).
 The framework is under fast, active development to support rapid
 analytics relating to COVID19; we're currently seeking funding to make
 it easier for outside collaborators to work with our system.  You can
-read our current roadmap [here](https://github.com/ebmdatalab/opensafely-research-template/blob/master/ROADMAP.md).
+read our current roadmap [here](https://github.com/ebmdatalab/opensafely-research-template/blob/main/ROADMAP.md).


### PR DESCRIPTION
For more information on why we're renaming master to main, see: opensafely/research-template#32.

When approved and merged, I'll rename the default branch. The GitHub UI gives instructions on how to update your local repository.