### PR TITLE
Replace database dependency with expectations for tests 

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -51,8 +51,6 @@ jobs:
     - name: Docker Run
       run: PYTHONPATH=. python run.py run --test
   test_model:
-    env:
-      DATABASE_URL: ${{ secrets.DUMMY_DATABASE_URL }}
     runs-on: ubuntu-latest
     name: Test stata can run against the actual model, using dummy data
     needs: test_stata
@@ -78,6 +76,6 @@ jobs:
     - name: Docker Pull
       run: docker pull docker.pkg.github.com/ebmdatalab/stata-docker-runner/stata-mp
     - name: Generate dummy data
-      run: PYTHONPATH=. python run.py generate_cohort --database-url $DATABASE_URL
+      run: PYTHONPATH=. python run.py generate_cohort
     - name: Run model
       run: PYTHONPATH=. python run.py run --analysis

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -334,18 +334,6 @@ study = StudyDefinition(
         return_last_date_in_period=True,
         include_month=True,
     ),
-    most_recent_unclear_smoking_cat=patients.with_these_clinical_events(
-        unclear_smoking_codes,
-        find_last_match_in_period=True,
-        on_or_before="2020-02-01",
-        returning="category",
-    ),
-    most_recent_unclear_smoking_numeric=patients.with_these_clinical_events(
-        unclear_smoking_codes,
-        find_last_match_in_period=True,
-        on_or_before="2020-02-01",
-        returning="numeric_value",
-    ),
     most_recent_unclear_smoking_cat_date=patients.with_these_clinical_events(
         unclear_smoking_codes,
         on_or_before="2020-02-01",

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -334,18 +334,18 @@ study = StudyDefinition(
         return_last_date_in_period=True,
         include_month=True,
     ),
-   # most_recent_unclear_smoking_cat=patients.with_these_clinical_events(
-   #     unclear_smoking_codes,
-   #     find_last_match_in_period=True,
-   #     on_or_before="2020-02-01",
-   #     returning="category",
-   # ),
-  #  most_recent_unclear_smoking_numeric=patients.with_these_clinical_events(
-  #      unclear_smoking_codes,
-  #      find_last_match_in_period=True,
-  #      on_or_before="2020-02-01",
-  #      returning="numeric_value",
-  #  ),
+    most_recent_unclear_smoking_cat=patients.with_these_clinical_events(
+        unclear_smoking_codes,
+        find_last_match_in_period=True,
+        on_or_before="2020-02-01",
+        returning="category",
+    ),
+    most_recent_unclear_smoking_numeric=patients.with_these_clinical_events(
+        unclear_smoking_codes,
+        find_last_match_in_period=True,
+        on_or_before="2020-02-01",
+        returning="numeric_value",
+    ),
     most_recent_unclear_smoking_cat_date=patients.with_these_clinical_events(
         unclear_smoking_codes,
         on_or_before="2020-02-01",

--- a/run.py
+++ b/run.py
@@ -253,7 +253,7 @@ def generate_cohort():
     sys.dont_write_bytecode = True
     from study_definition import study
 
-    study.to_csv("analysis/input.csv", expectations_population=True)
+    study.to_csv("analysis/input.csv", expectations_population=1000)
     print("Successfully created cohort and covariates at analysis/input.csv")
 
 

--- a/run.py
+++ b/run.py
@@ -253,8 +253,7 @@ def generate_cohort():
     sys.dont_write_bytecode = True
     from study_definition import study
 
-    with_sqlcmd = shutil.which("sqlcmd") is not None
-    study.to_csv("analysis/input.csv", with_sqlcmd=with_sqlcmd)
+    study.to_csv("analysis/input.csv", expectations_population=True)
     print("Successfully created cohort and covariates at analysis/input.csv")
 
 

--- a/run.py
+++ b/run.py
@@ -253,8 +253,13 @@ def generate_cohort():
     sys.dont_write_bytecode = True
     from study_definition import study
 
-    study.to_csv("analysis/input.csv", expectations_population=1000)
-    print("Successfully created cohort and covariates at analysis/input.csv")
+    input_filename = "analysis/input.csv"
+    with_sqlcmd = shutil.which("sqlcmd")
+    if os.environ.get("DATABASE_URL") and (with_sqlcmd is not None):
+        study.to_csv(input_filename, with_sqlcmd=with_sqlcmd)
+    else:
+        study.to_csv(input_filename, expectations_population=1000)
+    print(f"Successfully created cohort and covariates at {input_filename}")
 
 
 def make_cohort_report():
@@ -388,7 +393,6 @@ def main(from_cmd_line=False):
         "--database-url",
         help="Database URL to query",
         type=str,
-        required=True,
         default=os.environ.get("DATABASE_URL", ""),
     )
     if from_cmd_line:


### PR DESCRIPTION
Fixes #93.

Use generated data from expectations framework if no database is available.

Previously there was an actual database containing synthetic data, but this has now been shutdown.